### PR TITLE
feat(firestore): enable offline data

### DIFF
--- a/src/app/core/core.module.ts
+++ b/src/app/core/core.module.ts
@@ -17,7 +17,7 @@ import { AuthService } from './auth.service';
     AngularFireModule.initializeApp(environment.firebase),
     AngularFireAuthModule,
     AngularFireDatabaseModule,
-    AngularFirestoreModule,
+    AngularFirestoreModule.enablePersistence(),
     AngularFireStorageModule,
     CommonModule,
     MaterialModule

--- a/src/app/notes/components/note-add/note-add.component.ts
+++ b/src/app/notes/components/note-add/note-add.component.ts
@@ -37,11 +37,11 @@ export class NoteAddComponent implements OnInit {
     this.notesCollection = this.afs.collection<Note>(`notes`);
   }
 
-  async onSubmit() {
+  onSubmit() {
     if (this.noteForm.valid) {
       this.isLoading = true;
       this.note = this.prepareToSaveNote();
-      await this.notesCollection.add(this.note);
+      this.notesCollection.add(this.note);
 
       this.router.navigate(['/notes']);
     }

--- a/src/app/notes/components/notes-list/notes-list.component.ts
+++ b/src/app/notes/components/notes-list/notes-list.component.ts
@@ -19,8 +19,7 @@ export class NotesListComponent implements OnInit {
   ngOnInit() {
     this.notesCollection = this.afs.collection<Note>('notes');
     this.notes$ = this.notesCollection.snapshotChanges().map(actions => {
-      return actions.filter(item => !item.payload.doc.data().archived)
-                    .map(a => {
+      return actions.map(a => {
                       const data = a.payload.doc.data() as Note;
                       const id = a.payload.doc.id;
                       return { id, ...data };


### PR DESCRIPTION
With this step we have covered the following items:

- [x] Enable offline data with `AngularFirestoreModule.enablePersistence()`
- [x] Remove `async/await` in favor of Firestore data handling
- [x] Unused `archived` functionality

---
Closes #8 

<img width="1392" alt="024" src="https://user-images.githubusercontent.com/21221/39650415-eff6c350-4fdf-11e8-80cc-97e51700656f.png">
