### PR TITLE
feat(collaboration): send email via Cloud Functions

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -12,12 +12,16 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "~6.0.0",
-    "firebase-functions": "^2.0.5"
+    "firebase-functions": "^2.0.5",
+    "node-emoji": "^1.8.1",
+    "nodemailer": "^4.7.0"
   },
   "devDependencies": {
     "tslint": "~5.8.0",
     "typescript": "~2.8.3"
   },
   "private": true,
-  "engines": { "node": "8" } 
+  "engines": {
+    "node": "8"
+  }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,5 +1,7 @@
 import * as functions from 'firebase-functions';
 import * as admin from 'firebase-admin';
+import * as nodemailer from 'nodemailer';
+import * as nodemoji from 'node-emoji';
 
 const serviceAccount = require('../firebase-adminsdk-credentials.json');
 
@@ -69,3 +71,54 @@ export const deleteNoteAndTodos = functions.region('europe-west1').firestore
       console.log('Todos are gone!');
     });
   });
+
+
+// Configure the email transport using the default SMTP transport and a GMail account.
+// For Gmail, enable these:
+// 1. https://www.google.com/settings/security/lesssecureapps
+// 2. https://accounts.google.com/DisplayUnlockCaptcha
+// 3. firebase functions:config:set gmail.email="myusername@gmail.com" gmail.password="secretpassword"
+// For other types of transports such as Sendgrid see https://nodemailer.com/transports/
+// TODO: Configure the `gmail.email` and `gmail.password` Google Cloud environment variables.
+const gmailEmail = functions.config().gmail.email;
+const gmailPassword = functions.config().gmail.password;
+const mailTransport = nodemailer.createTransport({
+  service: 'gmail',
+  auth: {
+    user: gmailEmail,
+    pass: gmailPassword,
+  },
+});
+
+const APP_NAME = 'Firelist PWA';
+// Sends an email to the given collaborator.
+const sendEmail = async (mailOptions) => {
+  await mailTransport.sendMail(mailOptions);
+  console.log('New email sent to:', mailOptions.to);
+  return null;
+}
+
+// [START shareNoteViaEmail]
+export const shareNoteViaEmail = functions.firestore
+  .document('notes/{noteId}')
+  .onUpdate((change, context) => {
+    const previousNoteValue = change.before.data();
+    const newNoteValue = change.after.data();
+
+    if (newNoteValue.collaborators.length > previousNoteValue.collaborators.length) {
+      const randomEmoji = nodemoji.random();
+      const collaboratorEmail = newNoteValue.collaborators[newNoteValue.collaborators.length - 1];
+
+      const mailOptions = {
+        from: `${APP_NAME} <firelist.pwa@gmail.com>`,
+        to: collaboratorEmail,
+        subject: `${randomEmoji.emoji} You've received an invitation to collaborate`,
+        text: `Hey there!\n\nGreat news! You just got invited to collaborate. Access https://firelist-angular-dev.firebaseapp.com/note/${context.params.noteId} and have fun!\n\n-----------------\n${newNoteValue.title}\n${newNoteValue.description ? `${newNoteValue.description}\n` : ''}${newNoteValue.geolocation ? newNoteValue.geolocation.formatted_address : ''}`
+      };
+
+      return sendEmail(mailOptions);
+    } else {
+      return null;
+    }
+  });
+// [END shareNoteViaEmail]


### PR DESCRIPTION
With this step we have covered the following items:

- [x] Sending an email after sharing a note
- [x] Use [node-emoji](https://www.npmjs.com/package/node-emoji) to include a random emoji on the email's subject
---
<img width="1392" alt="screenshot 2018-11-24 14 04 09" src="https://user-images.githubusercontent.com/21221/48968585-a5a0d700-efe9-11e8-9e64-e8c9d458736b.png">


